### PR TITLE
add a flag "boot" for minimal dependencies, to be used by certain boot libs

### DIFF
--- a/these/src/Data/These.hs
+++ b/these/src/Data/These.hs
@@ -44,13 +44,17 @@ import Control.Applicative  (Applicative (..), (<$>))
 import Control.DeepSeq      (NFData (..))
 import Data.Bifoldable      (Bifoldable (..))
 import Data.Bifunctor       (Bifunctor (..))
+#ifdef MIN_VERSION_binary
 import Data.Binary          (Binary (..))
+#endif
 import Data.Bitraversable   (Bitraversable (..))
 import Data.Data            (Data, Typeable)
 import Data.Either          (partitionEithers)
 import Data.Foldable        (Foldable (..))
+#ifdef MIN_VERSION_hashable
 import Data.Hashable        (Hashable (..))
 import Data.Hashable.Lifted (Hashable1 (..), Hashable2 (..))
+#endif
 import Data.List.NonEmpty   (NonEmpty (..))
 import Data.Monoid          (Monoid (..))
 import Data.Semigroup       (Semigroup (..))
@@ -424,6 +428,7 @@ instance NFData2 These where
 -- binary
 -------------------------------------------------------------------------------
 
+#ifdef MIN_VERSION_binary
 -- | @since 0.7.1
 instance (Binary a, Binary b) => Binary (These a b) where
     put (This a)    = put (0 :: Int) >> put a
@@ -437,11 +442,13 @@ instance (Binary a, Binary b) => Binary (These a b) where
             1 -> That <$> get
             2 -> These <$> get <*> get
             _ -> fail "Invalid These index"
+#endif
 
 -------------------------------------------------------------------------------
 -- hashable
 -------------------------------------------------------------------------------
 
+#ifdef MIN_VERSION_hashable
 instance (Hashable a, Hashable b) => Hashable (These a b) where
     hashWithSalt salt (This a) =
         salt `hashWithSalt` (0 :: Int) `hashWithSalt` a
@@ -467,3 +474,4 @@ instance Hashable2 These where
         (salt `hashWithSalt` (1 :: Int)) `hashB` b
     liftHashWithSalt2  hashA  hashB salt (These a b) =
         (salt `hashWithSalt` (2 :: Int)) `hashA` a `hashB` b
+#endif

--- a/these/these.cabal
+++ b/these/these.cabal
@@ -55,6 +55,11 @@ flag assoc
   manual:      True
   default:     True
 
+flag boot
+  description: Build with minimal dependencies
+  manual:      True
+  default:     False
+
 library
   default-language: Haskell2010
   ghc-options:      -Wall
@@ -71,11 +76,12 @@ library
   -- ghc boot libs
   build-depends:
       base     >=4.5.1.0 && <4.16
-    , binary   >=0.5.1.0 && <0.10
     , deepseq  >=1.3.0.0 && <1.5
 
-  -- other dependencies
-  build-depends:    hashable >=1.2.7.0 && <1.4
+  if !flag(boot)
+    build-depends:
+        binary     >=0.5.1.0 && <0.10
+      , hashable   >=1.2.7.0 && <1.4
 
   if impl(ghc <7.5)
     build-depends: ghc-prim


### PR DESCRIPTION
As per haskellari/strict#29, I'm experimenting with de-duplicating StrictPair/StrictMaybe out of the containers library and need this flag to the dependency cycle strict -> binary -> containers -> strict.