### PR TITLE
build with ghc-9.2

### DIFF
--- a/monad-chronicle/monad-chronicle.cabal
+++ b/monad-chronicle/monad-chronicle.cabal
@@ -54,7 +54,7 @@ library
 
   -- ghc boot libs
   build-depends:
-      base          >=4.5.1.0 && <4.16
+      base          >=4.5.1.0 && <4.17
     , mtl           >=2.1.3   && <2.3
     , transformers  >=0.3.0.0 && <0.6
 

--- a/semialign-indexed/semialign-indexed.cabal
+++ b/semialign-indexed/semialign-indexed.cabal
@@ -45,6 +45,6 @@ library
   default-language:   Haskell2010
   ghc-options:        -Wall
   reexported-modules: Data.Semialign.Indexed
-  build-depends:      base >=4.10.0.0 && <4.16
+  build-depends:      base >=4.10.0.0 && <4.17
   build-depends:      semialign >=1.2 && <1.2.1
   build-depends:      lens ==5.*

--- a/semialign-optics/semialign-optics.cabal
+++ b/semialign-optics/semialign-optics.cabal
@@ -33,6 +33,6 @@ library
   default-language:   Haskell2010
   ghc-options:        -Wall
   reexported-modules: Data.Semialign.Indexed
-  build-depends:      base >=4.10.0.0 && <4.16
+  build-depends:      base >=4.10.0.0 && <4.17
   build-depends:      semialign >=1.2 && <1.2.1
   build-depends:      optics-core ==0.4.*

--- a/semialign/semialign.cabal
+++ b/semialign/semialign.cabal
@@ -64,7 +64,7 @@ library
 
   -- ghc boot libs
   build-depends:
-      base          >=4.5.1.0 && <4.16
+      base          >=4.5.1.0 && <4.17
     , containers    >=0.4.2.1 && <0.7
     , transformers  >=0.3.0.0 && <0.7
 

--- a/semialign/src/Data/Semialign/Internal.hs
+++ b/semialign/src/Data/Semialign/Internal.hs
@@ -28,7 +28,10 @@ import Data.List.NonEmpty                (NonEmpty (..))
 import Data.Maybe                        (catMaybes)
 import Data.Monoid                       (Monoid (..))
 import Data.Proxy                        (Proxy (..))
-import Data.Semigroup                    (Option (..), Semigroup (..))
+#if !MIN_VERSION_base(4,16,0)
+import Data.Semigroup                    (Option (..))
+#endif
+import Data.Semigroup                    (Semigroup (..))
 import Data.Sequence                     (Seq)
 import Data.Tagged                       (Tagged (..))
 import Data.Vector.Fusion.Stream.Monadic (Step (..), Stream (..))
@@ -481,12 +484,14 @@ instance SemialignWithIndex Int NonEmpty
 instance ZipWithIndex Int NonEmpty
 instance RepeatWithIndex Int NonEmpty
 
+#if !MIN_VERSION_base(4,16,0)
 deriving instance Semialign Option
 deriving instance Align Option
 deriving instance Unalign Option
 deriving instance Zip Option
 deriving instance Repeat Option
 deriving instance Unzip Option
+#endif
 
 {-
 deriving instance SemialignWithIndex () Option
@@ -742,7 +747,9 @@ instance Monad m => Semialign (Stream m) where
                 Done -> case (av, adone) of
                     (Just x, False) -> Yield (f $ This x) (sa, sb, Nothing, adone)
                     (_, True)       -> Done
+#if !MIN_VERSION_base(4,16,0)
                     _               -> Skip (sa, sb, Nothing, False)
+#endif
 
 instance Monad m => Zip (Stream m) where
     zipWith = Stream.zipWith

--- a/semialign/src/Data/Zip.hs
+++ b/semialign/src/Data/Zip.hs
@@ -35,7 +35,9 @@ instance (Zip f, Semigroup a) => Semigroup (Zippy f a) where
 
 instance (Repeat f, Monoid a) => Monoid (Zippy f a) where
     mempty                      = Zippy $ repeat mempty
+#if !MIN_VERSION_base(4,16,0)
     mappend (Zippy x) (Zippy y) = Zippy $ zipWith mappend x y
+#endif
 
 #ifdef MIN_VERSION_semigroupoids
 instance Zip f => Apply (Zippy f) where

--- a/these-lens/these-lens.cabal
+++ b/these-lens/these-lens.cabal
@@ -41,8 +41,8 @@ library
   exposed-modules:  Data.These.Lens
 
   -- ghc boot libs
-  build-depends:    base >=4.5.1.0 && <4.16
+  build-depends:    base >=4.5.1.0 && <4.17
   build-depends:    these >=1 && <1.2
 
   -- other dependencies
-  build-depends:    lens >=4.17.1 && <5.1
+  build-depends:    lens >=4.17.1 && <5.2

--- a/these-optics/these-optics.cabal
+++ b/these-optics/these-optics.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:  Data.These.Optics
 
   -- ghc boot libs
-  build-depends:    base >=4.9 && <4.16
+  build-depends:    base >=4.9 && <4.17
 
   -- these
   build-depends:    these >=1 && <1.2

--- a/these-tests/these-tests.cabal
+++ b/these-tests/these-tests.cabal
@@ -34,7 +34,7 @@ library
   default-language: Haskell2010
   hs-source-dirs:   src
   exposed-modules:  Dummy
-  build-depends:    base <4.16
+  build-depends:    base <4.17
 
 test-suite test
   default-language: Haskell2010

--- a/these/these.cabal
+++ b/these/these.cabal
@@ -70,7 +70,7 @@ library
 
   -- ghc boot libs
   build-depends:
-      base     >=4.5.1.0 && <4.16
+      base     >=4.5.1.0 && <4.17
     , binary   >=0.5.1.0 && <0.10
     , deepseq  >=1.3.0.0 && <1.5
 


### PR DESCRIPTION
tested with

```sh
cabal build all --allow-newer=base,template-haskell,ghc-prim,ghc-bignum
cabal test all --allow-newer=base,template-haskell,ghc-prim,ghc-bignum
```

This currently still requires the following source dependencies when building with ghc-9.2

```cabal
-- in the main branch
source-repository-package
  type: git
  location: https://github.com/nfrisby/invariant-functors
  tag: ac836de79c0ed23a407890c68a4db9552c01f9f4

-- in the main branch
source-repository-package
  type: git
  location: https://github.com/ekmett/lens
  tag: f76e2716be525657a408a6f43eaee26ace2e5b77

-- PR submitted
source-repository-package
  type: git
  location: https://github.com/hackage-package-forks/qc-instances
  tag: 066630fec39dda09ea600a61c763d2840dde7568
```