### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/monad-chronicle/src/Control/Monad/Trans/Chronicle.hs
+++ b/monad-chronicle/src/Control/Monad/Trans/Chronicle.hs
@@ -79,7 +79,6 @@ instance (Semigroup c, Applicative m) => Applicative (ChronicleT c m) where
     ChronicleT f <*> ChronicleT x = ChronicleT (liftA2 (<*>) f x)
 
 instance (Semigroup c, Monad m) => Monad (ChronicleT c m) where
-    return = ChronicleT . return . return
     m >>= k = ChronicleT $
         do cx <- runChronicleT m
            case cx of

--- a/semialign/semialign.cabal
+++ b/semialign/semialign.cabal
@@ -47,9 +47,6 @@ library
   default-language: Haskell2010
   ghc-options:      -Wall -Wno-trustworthy-safe
 
-  if impl(ghc >=9.2)
-    ghc-options: -Wno-noncanonical-monoid-instances
-
   hs-source-dirs:   src
   exposed-modules:
     Data.Align

--- a/semialign/src/Data/Zip.hs
+++ b/semialign/src/Data/Zip.hs
@@ -35,7 +35,6 @@ instance (Zip f, Semigroup a) => Semigroup (Zippy f a) where
 
 instance (Repeat f, Monoid a) => Monoid (Zippy f a) where
     mempty                      = Zippy $ repeat mempty
-    mappend (Zippy x) (Zippy y) = Zippy $ zipWith mappend x y
 
 #ifdef MIN_VERSION_semigroupoids
 instance Zip f => Apply (Zippy f) where


### PR DESCRIPTION
This appeases the -Wnoncanonical-monoid-instances and -Wnoncanonical-monad-instances warnings. These warnings exist because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/semigroup-monoid