### PR TITLE
Move Unzip to the bottom of type-class hierarchy

### DIFF
--- a/semialign/CHANGELOG.md
+++ b/semialign/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.4
+
+- Reorder class hierarchy. `Unzip` is now at the bottom, right above `Functor`.
+  There are two ways things may break:
+  - You may need to add `Unzip` instance if you haven't one already, for example:
+    `instance Unzip ((->) e) where unzip = unzipDefault` was added in this patch.
+  - `Unzip f` doesn't imply whole hierarchy, so you may need to change `Unzip f` to `Zip f`
+    in the constraints of some of your functions.
+
 # 1.3.1
 
 - Support GHC-8.6.5...GHC-9.10.1

--- a/semialign/semialign.cabal
+++ b/semialign/semialign.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               semialign
-version:            1.3.1.1
+version:            1.4
 synopsis:
   Align and Zip type-classes from the common Semialign ancestor.
 

--- a/semialign/src/Data/Semialign/Internal.hs
+++ b/semialign/src/Data/Semialign/Internal.hs
@@ -121,7 +121,7 @@ oops = error . ("Data.Align: internal error: " ++)
 --          ≡ mapMaybe justHere (toList (align x y))
 -- @
 --
-class Functor f => Semialign f where
+class Unzip f => Semialign f where
     -- | Analogous to @'zip'@, combines two structures by taking the union of
     --   their shapes and using @'These'@ to hold the elements.
     align :: f a -> f b -> f (These a b)
@@ -295,7 +295,7 @@ class Zip f => Repeat f where
 --
 -- For sequence-like types this holds, but for Map-like it doesn't.
 --
-class Zip f => Unzip f where
+class Functor f => Unzip f where
     unzipWith :: (c -> (a, b)) -> f c -> (f a, f b)
     unzipWith f = unzip . fmap f
 
@@ -336,6 +336,12 @@ class (ZipWithIndex i f, Repeat f) => RepeatWithIndex i f | f -> i where
 -------------------------------------------------------------------------------
 -- base
 -------------------------------------------------------------------------------
+
+-- |
+--
+-- @since 1.4
+instance Unzip ((->) e) where
+    unzip = unzipDefault
 
 instance Semialign ((->) e) where
     align f g x = These (f x) (g x)
@@ -661,6 +667,13 @@ instance (RepeatWithIndex i f, RepeatWithIndex j g) => RepeatWithIndex (i, j) (C
 -------------------------------------------------------------------------------
 
 -- Based on the Data.Vector.Fusion.Stream.Monadic zipWith implementation
+
+-- |
+--
+-- @since 1.4
+instance Monad m => Unzip (Stream m) where
+    unzip = unzipDefault
+
 instance Monad m => Align (Stream m) where
     nil = Stream.empty
 
@@ -688,8 +701,15 @@ instance Monad m => Semialign (Stream m) where
                     _               -> Skip (sa, sb, Nothing, False)
 #endif
 
+
 instance Monad m => Zip (Stream m) where
     zipWith = Stream.zipWith
+
+-- |
+--
+-- @since 1.4
+instance Monad m => Unzip (Bundle m v) where
+    unzip = unzipDefault
 
 instance Monad m => Align (Bundle m v) where
     nil = Bundle.empty

--- a/these-tests/test/Tests/AlignWrong.hs
+++ b/these-tests/test/Tests/AlignWrong.hs
@@ -18,6 +18,9 @@ import Data.These
 
 newtype WrongMap k v = WM (Map k v) deriving (Eq, Ord, Show, Functor, Foldable)
 
+instance Unzip (WrongMap k) where
+    unzip = unzipDefault
+
 instance (Arbitrary k, Arbitrary v, Ord k) => Arbitrary (WrongMap k v) where
     arbitrary = WM <$> arbitrary
     shrink (WM m) = WM <$> shrink m
@@ -46,6 +49,9 @@ instance Ord k => Zip (WrongMap k) where
 newtype WeirdMap k v = WeirdMap (Map k v)
   deriving (Eq, Ord, Show, Functor, Foldable)
 
+instance Unzip (WeirdMap k) where
+    unzip = unzipDefault
+
 instance (Arbitrary k, Arbitrary v, Ord k) => Arbitrary (WeirdMap k v) where
     arbitrary = WeirdMap <$> arbitrary
     shrink (WeirdMap m) = WeirdMap <$> shrink m
@@ -72,6 +78,9 @@ instance Ord k => Zip (WeirdMap k) where
 
 newtype R a = Nest [[a]]
   deriving (Show, Eq, Ord, Functor, Foldable)
+
+instance Unzip R where
+    unzip = unzipDefault
 
 instance Align R where
     nil = Nest []

--- a/these-tests/test/Tests/Semialign.hs
+++ b/these-tests/test/Tests/Semialign.hs
@@ -114,7 +114,7 @@ data CSemialign f where
 
 semialignLaws
     :: forall (f :: * -> *).
-       ( Semialign f, Unzip f, Foldable f, Typeable f
+       ( Semialign f, Zip f, Foldable f, Typeable f
        , Eq (f A), Show (f A), Arbitrary (f A)
        , Eq (f B), Show (f B), Arbitrary (f B)
        , Eq (f C), Show (f C), Arbitrary (f C)
@@ -357,7 +357,7 @@ unalignLaws' _ = testGroup "Unalign"
 
 
 unzipLaws'
-    :: forall f proxy. (Unzip f
+    :: forall f proxy. (Zip f
        , Eq (f A), Show (f A), Arbitrary (f A)
        , Eq (f B), Show (f B), Arbitrary (f B)
        , Eq (f C), Show (f C), Arbitrary (f C)


### PR DESCRIPTION
Every Functor can be Unzip. Some can be more efficient than default.