### PR TITLE
Maybe pr

### DIFF
--- a/these/src/Data/These.hs
+++ b/these/src/Data/These.hs
@@ -6,6 +6,9 @@
 module Data.These (
       These(..)
 
+    -- * Functions to make 'These'
+    , maybeThese
+
     -- * Functions to get rid of 'These'
     , these
     , fromThese
@@ -49,9 +52,9 @@ import Data.Semigroup       (Semigroup (..))
 import Data.Traversable     (Traversable (..))
 import GHC.Generics         (Generic, Generic1)
 import Prelude
-       (Bool (..), Either (..), Eq (..), Functor (..), Int, Monad (..),
-       Ord (..), Ordering (..), Read (..), Show (..), fail, id, lex, readParen,
-       seq, showParen, showString, ($), (&&), (.))
+       (Bool (..), Either (..), Eq (..), Functor (..), Int, Maybe(..),
+       Monad (..), Ord (..), Ordering (..), Read (..), Show (..), fail, id,
+       lex, readParen, seq, showParen, showString, ($), (&&), (.))
 
 -- $setup
 -- >>> import Control.Lens
@@ -74,6 +77,18 @@ import Prelude
 --   "Data.Align".
 data These a b = This a | That b | These a b
   deriving (Eq, Ord, Read, Show, Typeable, Data, Generic, Generic1)
+
+
+-------------------------------------------------------------------------------
+-- Constructors
+-------------------------------------------------------------------------------
+
+-- | Realises the isomorphism @('Maybe' A, 'Maybe' B) = 'Maybe' ('These' A B)@
+maybeThese :: Maybe a -> Maybe b -> Maybe (These a b)
+maybeThese (Just x) (Just y) = Just (These x y)
+maybeThese (Just x) Nothing = Just (This x)
+maybeThese Nothing (Just y) = Just (That y)
+maybeThese Nothing Nothing = Nothing
 
 -------------------------------------------------------------------------------
 -- Eliminators

--- a/these/these.cabal
+++ b/these/these.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               these
-version:            1.2.1
+version:            1.3
 x-revision:         2
 synopsis:           An either-or-both data type.
 homepage:           https://github.com/haskellari/these


### PR DESCRIPTION
This adds an function realising an important property of `These`. I've found the function useful in practice: for example, it allows one to make data structures containing `These` via `mapMaybe`. The reverse isomorphism is not really required, since it has coordinates `justHere` and `justThere`, which already exist.

I'd be happy putting it in `Data.These.Combinators` instead; to me it seems just as comfortable in the main file; the division is not very clear-cut.