### PR TITLE
MoNR: Remove extraneous method definitions

### DIFF
--- a/monad-chronicle/src/Control/Monad/Trans/Chronicle.hs
+++ b/monad-chronicle/src/Control/Monad/Trans/Chronicle.hs
@@ -79,7 +79,6 @@ instance (Semigroup c, Applicative m) => Applicative (ChronicleT c m) where
     ChronicleT f <*> ChronicleT x = ChronicleT (liftA2 (<*>) f x)
 
 instance (Semigroup c, Monad m) => Monad (ChronicleT c m) where
-    return = ChronicleT . return . return
     m >>= k = ChronicleT $
         do cx <- runChronicleT m
            case cx of

--- a/semialign/src/Data/Zip.hs
+++ b/semialign/src/Data/Zip.hs
@@ -35,7 +35,6 @@ instance (Zip f, Semigroup a) => Semigroup (Zippy f a) where
 
 instance (Repeat f, Monoid a) => Monoid (Zippy f a) where
     mempty                      = Zippy $ repeat mempty
-    mappend (Zippy x) (Zippy y) = Zippy $ zipWith mappend x y
 
 #ifdef MIN_VERSION_semigroupoids
 instance Zip f => Apply (Zippy f) where

--- a/these/src/Data/These.hs
+++ b/these/src/Data/These.hs
@@ -247,7 +247,6 @@ instance (Semigroup a) => Applicative (These a) where
 
 
 instance (Semigroup a) => Monad (These a) where
-    return = pure
     This  a   >>= _ = This a
     That    x >>= k = k x
     These a x >>= k = case k x of


### PR DESCRIPTION
Hi,
As part of https://github.com/haskell/core-libraries-committee/issues/418, I'm opening this PR to remove the definitions of return and mappend in monad-chronicle, semialign, and these.

I'm aware that you won't merge this until [changes have been made to GHC](https://github.com/haskellari/these/pull/206), but I ask that you leave this open until that point.